### PR TITLE
Check out target branch before upload

### DIFF
--- a/yacr.sh
+++ b/yacr.sh
@@ -256,6 +256,7 @@ package_chart() {
 }
 
 release_charts() {
+    git checkout gh-pages
     local args=(-o "$owner" -r "$repo" -c "$(git rev-parse HEAD)")
     if [[ -n "$config" ]]; then
         args+=(--config "$config")


### PR DESCRIPTION
Fixes the below error by checking out the `gh-page` branch before pushing the commit:

```
[main 7126ae5] Update index.yaml
 2 files changed, 14 insertions(+)
 create mode 100644 somechart-0.1.1.tgz
 create mode 100644 index.yaml
Pushing to branch "gh-pages"
To https://github.com/someorg/somerepo
 ! [rejected]        HEAD -> gh-pages (non-fast-forward)
error: failed to push some refs to 'https://github.com/someorg/somerepo'
hint: Updates were rejected because a pushed branch tip is behind its remote
hint: counterpart. Check out this branch and integrate the remote changes
hint: (e.g. 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Error: exit status 1
```

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>